### PR TITLE
Update vector_icon.js

### DIFF
--- a/src/js/vector_icon.js
+++ b/src/js/vector_icon.js
@@ -205,6 +205,9 @@ class VectorIcon {
       'CUBIC_TO': 'C',
       'R_CUBIC_TO': 'c',
       'CUBIC_TO_SHORTHAND': 'S',
+      'QUADRATIC_TO': 'Q',
+      'R_QUADRATIC_TO': 'q',
+      'QUADRATIC_TO_SHORTHAND': 'T',
       'CLOSE': 'Z',
     };
     if (cmd[0] in drawCommands) {


### PR DESCRIPTION
Add support for QUADRATIC_TO, R_QUADRATIC_TO, QUADRATIC_TO_SHORTHAND to fix drawing of rounded icons

Should resolve Issue #1 

Please note that although most icons are fine now some notably google_color.icon and settings.icon have a doubling affect... Probably due to multiple Sizes specified by the CANVAS_DIMENSIONS tags.

I have attached screenshots of the resulting icons after my fix including the google_color.icon doubling affect. I have chosen to not include screenshots of the icons before my fix because they were just blank boxes.

![Screenshot 2023-04-15 093130](https://user-images.githubusercontent.com/2529736/232227097-146e0c56-3d4e-4aeb-b8db-f70445d0bf7f.jpg)
![Screenshot 2023-04-15 093215](https://user-images.githubusercontent.com/2529736/232227098-ede37d58-0bd0-4df2-b598-7bd6949332ee.jpg)
![Screenshot 2023-04-15 093248](https://user-images.githubusercontent.com/2529736/232227099-c4421514-6766-48ea-ba2e-0231ddd0c28b.jpg)
